### PR TITLE
:sparkles: secure logging management

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,6 +85,7 @@ func (c *Config) WithInited() *Config {
 
 	c.Network.WithInited()
 	c.Defaults.WithInited()
+	c.Defaults.Global.OS.WithDefaults()
 	c.K8S.WithInited()
 	c.Nodepools.WithInited()
 	c.Nodepools.SpecifyLeader()

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/hetzner/network"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/k8s/k8sconfig"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/k3s"
+	osconfig "github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/os/config"
 )
 
 type WithID interface {
@@ -68,6 +69,8 @@ type NodeConfig struct {
 	// Role specifies the role of the server (server or agent).
 	// Default is computed.
 	Role string `json:"-" yaml:"-" mapstructure:"-"`
+	// OS defines configuration for operating system.
+	OS *osconfig.OSConfig
 }
 
 func (n *NodeConfig) GetID() string {
@@ -129,6 +132,10 @@ func (d *DefaultConfig) WithInited() *DefaultConfig {
 
 	if d.Global.K3s == nil {
 		d.Global.K3s = &k3s.Config{}
+	}
+
+	if d.Global.OS == nil {
+		d.Global.OS = &osconfig.OSConfig{}
 	}
 
 	if d.Global.K8S == nil {

--- a/internal/program/pulumi.go
+++ b/internal/program/pulumi.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes"
 	corev1 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/core/v1"
 	helmv3 "github.com/pulumi/pulumi-kubernetes/sdk/v4/go/kubernetes/helm/v3"
+	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
 	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
 	remotefile "github.com/spigell/pulumi-file/sdk/go/file/remote"
 	upgradev1 "github.com/spigell/pulumi-hcloud-kube-hetzner/crds/generated/rancher/upgrade/v1"
@@ -24,6 +25,10 @@ type resourceArgs interface {
 		*local.CommandArgs |
 		*remotefile.FileArgs |
 		*remote.CommandArgs |
+		*tls.PrivateKeyArgs |
+		*tls.LocallySignedCertArgs |
+		*tls.SelfSignedCertArgs |
+		*tls.CertRequestArgs |
 		*kubernetes.ProviderArgs |
 		*corev1.NodePatchArgs |
 		*corev1.SecretArgs |
@@ -43,6 +48,10 @@ type resources interface {
 		*local.Command |
 		*remote.Command |
 		*remotefile.File |
+		*tls.CertRequest |
+		*tls.PrivateKey |
+		*tls.SelfSignedCert |
+		*tls.LocallySignedCert |
 		*kubernetes.Provider |
 		*corev1.NodePatch |
 		*corev1.Secret |

--- a/internal/system/info/info.go
+++ b/internal/system/info/info.go
@@ -1,6 +1,11 @@
 package info
 
-import "github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/variables"
+import (
+	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/variables"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/utils/pki"
+)
 
 type OSInfo interface {
 	// sftpServerPath is a path to sftp-server binary.
@@ -9,12 +14,20 @@ type OSInfo interface {
 }
 
 type Info struct {
-	leader bool
+	leader   bool
+	leaderIP pulumi.StringOutput
 
 	communicationMethod variables.CommunicationMethod
 	communicationIface  string
 
 	k8sEndpointType string
+
+	journaldLeader *JournaldLeader
+}
+
+type JournaldLeader struct {
+	Issuer  *pki.PKI
+	Restart *remote.Command
 }
 
 func New() *Info {
@@ -33,6 +46,18 @@ func (i *Info) WithCommunicationMethod(method variables.CommunicationMethod) *In
 
 func (i *Info) WithK8SEndpointType(t string) *Info {
 	i.k8sEndpointType = t
+
+	return i
+}
+
+func (i *Info) WithLeaderIP(ip pulumi.StringOutput) *Info {
+	i.leaderIP = ip
+
+	return i
+}
+
+func (i *Info) WithJournaldLeader(leader *JournaldLeader) *Info {
+	i.journaldLeader = leader
 
 	return i
 }
@@ -57,4 +82,12 @@ func (i *Info) CommunicationIface() string {
 
 func (i *Info) Leader() bool {
 	return i.leader
+}
+
+func (i *Info) LeaderIP() pulumi.StringOutput {
+	return i.leaderIP
+}
+
+func (i *Info) JournaldLeader() *JournaldLeader {
+	return i.journaldLeader
 }

--- a/internal/system/modules/journald/config.go
+++ b/internal/system/modules/journald/config.go
@@ -1,0 +1,23 @@
+package journald
+
+var (
+	defaultGatherAuditD   = true
+	defaultGatherToLeader = true
+)
+
+type Config struct {
+	GatherAuditD   *bool `json:"gather-auditd" yaml:"gather-auditd" mapstructure:"gather-auditd"`
+	GatherToLeader *bool `json:"gather-to-leader" yaml:"gather-to-leader" mapstructure:"gather-to-leader"`
+}
+
+func (c *Config) WithDefaults() *Config {
+	if c.GatherAuditD == nil {
+		c.GatherAuditD = &defaultGatherAuditD
+	}
+
+	if c.GatherToLeader == nil {
+		c.GatherToLeader = &defaultGatherToLeader
+	}
+
+	return c
+}

--- a/internal/system/modules/journald/journald.go
+++ b/internal/system/modules/journald/journald.go
@@ -1,0 +1,62 @@
+package journald
+
+import (
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/info"
+)
+
+type JournalD struct {
+	order  int
+	ID     string
+	OS     info.OSInfo
+	System *info.Info
+
+	Config *Config
+}
+
+func New(id string, os info.OSInfo, config *Config) *JournalD {
+	return &JournalD{
+		ID:     id,
+		OS:     os,
+		Config: config.WithDefaults(),
+	}
+}
+
+func (j *JournalD) RequiredPkgs() []string {
+	packages := make([]string, 0)
+	if *j.Config.GatherToLeader {
+		packages = append(packages, "systemd-journal-remote")
+	}
+	return packages
+}
+
+func (j *JournalD) SetOrder(order int) {
+	j.order = order
+}
+
+func (j *JournalD) Order() int {
+	return j.order
+}
+
+func (j *JournalD) WithSysInfo(info *info.Info) *JournalD {
+	j.System = info
+
+	return j
+}
+
+type Provisioned struct {
+	resources []pulumi.Resource
+	outputs   *Outputs
+}
+
+type Outputs struct {
+	JournalDLeader *info.JournaldLeader
+}
+
+func (p *Provisioned) Resources() []pulumi.Resource {
+	return p.resources
+}
+
+func (p *Provisioned) Value() any {
+	return p.outputs
+}

--- a/internal/system/modules/journald/manage.go
+++ b/internal/system/modules/journald/manage.go
@@ -1,0 +1,277 @@
+package journald
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/pulumi/pulumi-command/sdk/go/command/remote"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	remotefile "github.com/spigell/pulumi-file/sdk/go/file/remote"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/program"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/info"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/utils/pki"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/utils/ssh/connection"
+)
+
+var restartSystemDTemplate = strings.Join([]string{
+	"sudo systemctl daemon-reload",
+	"sudo systemctl disable --now %[1]s",
+	"sudo systemctl enable --now %[1]s",
+	"sudo systemctl status %[1]s",
+	"echo 'systemctl status command returned' $? exit code",
+}, " && ")
+
+var (
+	jourlandCAPemFile      = "/etc/systemd/journald.conf.d/ca.pem"
+	uploaderCertPath       = "/etc/systemd/journal-upload.conf.d/cert.pem"
+	uploaderPrivateKeyPath = "/etc/systemd/journal-upload.conf.d/key.pem"
+	receiverCertPath       = "/etc/systemd/journal-remote.conf.d/cert.pem"
+	receiverPrivateKeyPath = "/etc/systemd/journal-remote.conf.d/key.pem"
+)
+
+var auditCMD = strings.Join([]string{
+	"sudo systemctl %s systemd-journald-audit.socket",
+	"sudo systemctl restart systemd-journald",
+	"sudo systemctl restart auditd",
+}, " && ")
+
+// Up configures journald.
+func (j *JournalD) Up(ctx *program.Context, con *connection.Connection, deps []pulumi.Resource, _ []interface{}) (modules.Output, error) {
+	resources := make([]pulumi.Resource, 0)
+
+	auditAction := "enable"
+	if !*j.Config.GatherAuditD {
+		auditAction = "disable --now"
+	}
+
+	auditd, err := program.PulumiRun(ctx, remote.NewCommand, fmt.Sprintf("enable-auditd-socket:%s", j.ID), &remote.CommandArgs{
+		Connection: con.RemoteCommand(),
+		Create:     pulumi.Sprintf(auditCMD, auditAction),
+	}, pulumi.DependsOn(deps), pulumi.DeleteBeforeReplace(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to manage journald-auditd integration: %w", err)
+	}
+	resources = append(resources, auditd)
+
+	outputs := &Outputs{}
+
+	if j.System.Leader() {
+		issuer, err := pki.New(ctx, "journald-gather-ca")
+		if err != nil {
+			return nil, fmt.Errorf("failed to create journald pki: %w", err)
+		}
+		cert, err := issuer.NewCertificate(fmt.Sprintf("journald-receiver:%s", j.ID),
+			pki.WithIPAddesses(pulumi.StringArray{
+				j.System.LeaderIP(),
+			}),
+			pki.WithAllowedUsages([]string{"server_auth"}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create server cert: %w", err)
+		}
+
+		receiver, err := j.setupReceiver(ctx, con, cert, resources)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create journald recevier: %w", err)
+		}
+
+		resources = append(resources, receiver)
+
+		journalDleader := &info.JournaldLeader{
+			Issuer:  issuer,
+			Restart: receiver,
+		}
+
+		j.System = j.System.WithJournaldLeader(journalDleader)
+		outputs.JournalDLeader = journalDleader
+	}
+
+	_, err = program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-ca-cert:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.String(jourlandCAPemFile),
+		Content:     j.System.JournaldLeader().Issuer.CertificatePem,
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn(deps))
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy journald CA cert: %w", err)
+	}
+
+	if *j.Config.GatherToLeader {
+		cert, err := j.System.JournaldLeader().Issuer.NewCertificate(
+			fmt.Sprintf("journald-uploader:%s", j.ID),
+			pki.WithAllowedUsages([]string{"client_auth"}),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create journald uploader cert: %w", err)
+		}
+
+		uploader, err := j.setupUploader(ctx, con, cert, j.System.JournaldLeader().Restart)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create journald uploader: %w", err)
+		}
+		resources = append(resources, uploader...)
+	}
+
+	return &Provisioned{
+		resources: resources,
+		outputs:   outputs,
+	}, nil
+}
+
+func (j *JournalD) setupReceiver(ctx *program.Context, con *connection.Connection, cert *pki.Certificate, deps []pulumi.Resource) (*remote.Command, error) {
+	serviceName := "systemd-journal-remote.service"
+	socketName := "systemd-journal-remote.socket"
+
+	certDeployed, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-receiver-cert:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.String(receiverCertPath),
+		Content:     cert.CertificatePem,
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn(deps))
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy receiver cert: %w", err)
+	}
+
+	keyDeployed, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-receiver-privatekey:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.String(receiverPrivateKeyPath),
+		Content:     cert.PrivateKeyPem,
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("600"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn(deps))
+	if err != nil {
+		return nil, fmt.Errorf("failed to deploy receiver private key: %w", err)
+	}
+
+	service, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-remote-service:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.Sprintf("/etc/systemd/system/%s", serviceName),
+		Content:     pulumi.String(receiverServiceTemplate),
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn(deps))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create systemd unit configuration file: %w", err)
+	}
+
+	config, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-remote-config:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.String("/etc/systemd/journal-remote.conf.d/phkh.conf"),
+		Content:     pulumi.Sprintf(receiverConfigTemplate, jourlandCAPemFile, certDeployed.Path, keyDeployed.Path),
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("600"),
+	}, pulumi.RetainOnDelete(true))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create receiver configuration file: %w", err)
+	}
+
+	enable, err := program.PulumiRun(ctx, remote.NewCommand, fmt.Sprintf("enable-journald-remote-service:%s", j.ID), &remote.CommandArgs{
+		Connection: con.RemoteCommand(),
+		Create:     pulumi.Sprintf(restartSystemDTemplate, socketName),
+		Triggers: pulumi.Array{
+			service.Md5sum,
+			service.Connection,
+			service.Path,
+			certDeployed.Md5sum,
+			certDeployed.Connection,
+			certDeployed.Permissions,
+			certDeployed.Path,
+			keyDeployed.Md5sum,
+			keyDeployed.Connection,
+			keyDeployed.Permissions,
+			keyDeployed.Path,
+			config.Md5sum,
+			config.Connection,
+			config.Path,
+		},
+	},
+		pulumi.DeleteBeforeReplace(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create enable journald remote server: %w", err)
+	}
+
+	return enable, nil
+}
+
+func (j *JournalD) setupUploader(ctx *program.Context, con *connection.Connection, cert *pki.Certificate, receiver *remote.Command) ([]pulumi.Resource, error) {
+	serviceName := "systemd-journal-upload.service"
+
+	certDeployed, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-uploader-cert:%s", j.ID), &remotefile.FileArgs{
+		Connection:  con.RemoteFile(),
+		UseSudo:     pulumi.Bool(true),
+		Path:        pulumi.String(uploaderCertPath),
+		Content:     cert.CertificatePem,
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn([]pulumi.Resource{receiver}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ssh configuration file: %w", err)
+	}
+
+	keyDeployed, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-uploader-privatekey:%s", j.ID), &remotefile.FileArgs{
+		Connection: con.RemoteFile(),
+		UseSudo:    pulumi.Bool(true),
+		Path:       pulumi.String(uploaderPrivateKeyPath),
+		Content:    cert.PrivateKeyPem,
+		SftpPath:   pulumi.String(j.OS.SFTPServerPath()),
+		// TO DO: fix owner
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn([]pulumi.Resource{receiver}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create uploader cert: %w", err)
+	}
+	config, err := program.PulumiRun(ctx, remotefile.NewFile, fmt.Sprintf("add-journald-upload-config:%s", j.ID), &remotefile.FileArgs{
+		Connection: con.RemoteFile(),
+		UseSudo:    pulumi.Bool(true),
+		Path:       pulumi.String("/etc/systemd/journal-upload.conf.d/phkh.conf"),
+		Content: pulumi.Sprintf(uploadTemplate,
+			j.System.LeaderIP(),
+			jourlandCAPemFile,
+			certDeployed.Path,
+			keyDeployed.Path,
+		),
+		SftpPath:    pulumi.String(j.OS.SFTPServerPath()),
+		Permissions: pulumi.String("644"),
+	}, pulumi.RetainOnDelete(true), pulumi.DependsOn([]pulumi.Resource{receiver}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create uploader configuration file: %w", err)
+	}
+
+	enable, err := program.PulumiRun(ctx, remote.NewCommand, fmt.Sprintf("enable-journald-upload-service:%s", j.ID), &remote.CommandArgs{
+		Connection: con.RemoteCommand(),
+		Create:     pulumi.Sprintf(restartSystemDTemplate, serviceName),
+		Triggers: pulumi.Array{
+			receiver.Create,
+			config.Md5sum,
+			config.Connection,
+			config.Path,
+			certDeployed.Md5sum,
+			certDeployed.Connection,
+			certDeployed.Permissions,
+			certDeployed.Path,
+			keyDeployed.Md5sum,
+			keyDeployed.Connection,
+			keyDeployed.Permissions,
+			keyDeployed.Path,
+		},
+	},
+		pulumi.DeleteBeforeReplace(true),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to enable uploader service: %w", err)
+	}
+
+	return []pulumi.Resource{
+		config,
+		enable,
+	}, nil
+}

--- a/internal/system/modules/journald/templates.go
+++ b/internal/system/modules/journald/templates.go
@@ -1,0 +1,62 @@
+package journald
+
+var uploadTemplate = `
+
+[Upload]
+URL=https://%s:19532
+
+TrustedCertificateFile=%s
+ServerCertificateFile=%s
+ServerKeyFile=%s
+
+`
+
+var receiverServiceTemplate = `
+
+[Unit]
+Description=Journal Remote Sink Service
+Documentation=man:systemd-journal-remote(8) man:journal-remote.conf(5)
+Requires=systemd-journal-remote.socket
+
+[Service]
+ExecStart=/usr/lib/systemd/systemd-journal-remote --listen-https=-3 --output=/var/log/journal/remote/
+LockPersonality=yes
+LogsDirectory=journal/remote
+MemoryDenyWriteExecute=yes
+NoNewPrivileges=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+PrivateTmp=yes
+ProtectProc=invisible
+ProtectClock=yes
+ProtectControlGroups=yes
+ProtectHome=yes
+ProtectHostname=yes
+ProtectKernelLogs=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+ProtectSystem=strict
+RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6
+RestrictNamespaces=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+SystemCallArchitectures=native
+WatchdogSec=3min
+
+[Install]
+Also=systemd-journal-remote.socket
+
+`
+
+var receiverConfigTemplate = `
+
+[Remote]
+
+SplitMode=host
+TrustedCertificateFile=%s
+ServerCertificateFile=%s
+ServerKeyFile=%s
+
+MaxUse=3G
+
+`

--- a/internal/system/modules/k3s/k3s.go
+++ b/internal/system/modules/k3s/k3s.go
@@ -16,7 +16,6 @@ import (
 const (
 	// ManagedLabel is a label for node Label. Used for internal purposes.
 	NodeManagedLabel = "phkh.io/managed=true"
-	logDir           = "/var/lib/rancher/k3s/server/logs"
 	auditPolicyFIle  = "/var/lib/audit.yaml"
 )
 
@@ -105,10 +104,7 @@ func (k *K3S) WithK8SAuditLog(log *audit.AuditLog) *K3S {
 		k.auditPolicyContent = log.PolicyContent()
 		k.Config.K3S.KubeAPIServerArgs = append(k.Config.K3S.KubeAPIServerArgs,
 			fmt.Sprintf("audit-policy-file=%s", auditPolicyFIle),
-			fmt.Sprintf("audit-log-path=%s/audit.log", logDir),
-			fmt.Sprintf("audit-log-maxage=%d", log.AuditLogMaxAge()),
-			fmt.Sprintf("audit-log-maxbackup=%d", log.AuditLogMaxBackup()),
-			fmt.Sprintf("audit-log-maxsize=%d", log.AuditLogMaxSize()),
+			"audit-log-path=-",
 		)
 	}
 

--- a/internal/system/os/config/config.go
+++ b/internal/system/os/config/config.go
@@ -1,0 +1,17 @@
+package osconfig
+
+import (
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/journald"
+)
+
+type OSConfig struct {
+	JournalD *journald.Config
+}
+
+func (o *OSConfig) WithDefaults() *OSConfig {
+	if o.JournalD == nil {
+		o.JournalD = &journald.Config{}
+	}
+
+	return o
+}

--- a/internal/system/os/microos/microos.go
+++ b/internal/system/os/microos/microos.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/k8s/audit"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/program"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/journald"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/k3s"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/sshd"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/os"
@@ -118,6 +119,14 @@ func (m *MicroOS) SetupSSHD(config *sshd.Params) {
 
 	module.SetOrder(AfterNetwork)
 	m.modules[variables.SSHD] = module
+}
+
+func (m *MicroOS) SetupJournalD(config *journald.Config) {
+	module := journald.New(m.ID, &MicroOS{}, config)
+	m.AddAdditionalRequiredPackages(module.RequiredPkgs())
+
+	module.SetOrder(AfterReboot)
+	m.modules[variables.JournalD] = module
 }
 
 func (m *MicroOS) AddK3SModule(role string, config *k3s.Config, auditLog *audit.AuditLog) {

--- a/internal/system/os/os.go
+++ b/internal/system/os/os.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/k8s/audit"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/program"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/journald"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/k3s"
 	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/system/modules/sshd"
 
@@ -14,6 +15,7 @@ import (
 type OperatingSystem interface {
 	Up(*program.Context, *hetzner.Server, map[string][]pulumi.Resource) (Provisioned, error)
 	SetupSSHD(*sshd.Params)
+	SetupJournalD(*journald.Config)
 	AddK3SModule(string, *k3s.Config, *audit.AuditLog)
 
 	AddAdditionalRequiredPackages([]string)

--- a/internal/system/variables/variables.go
+++ b/internal/system/variables/variables.go
@@ -9,8 +9,9 @@ const (
 	PublicIface  = "eth0"
 	PrivateIface = "eth1"
 	// Name of modules.
-	K3s  = "k3s"
-	SSHD = "sshd"
+	K3s      = "k3s"
+	SSHD     = "sshd"
+	JournalD = "journald"
 )
 
 type CommunicationMethod string

--- a/internal/utils/pki/pki.go
+++ b/internal/utils/pki/pki.go
@@ -1,0 +1,113 @@
+package pki
+
+import (
+	"fmt"
+
+	"github.com/pulumi/pulumi-tls/sdk/v4/go/tls"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+	"github.com/spigell/pulumi-hcloud-kube-hetzner/internal/program"
+)
+
+type Certificate struct {
+	allowedUsages []string
+	ipAddreses    pulumi.StringArray
+
+	PrivateKeyPem  pulumi.StringOutput
+	CertificatePem pulumi.StringOutput
+}
+type PKI struct {
+	ctx *program.Context
+
+	*Certificate
+}
+
+func New(ctx *program.Context, name string) (*PKI, error) {
+	key, err := program.PulumiRun(ctx, tls.NewPrivateKey, fmt.Sprintf("ca-key:%s", name), &tls.PrivateKeyArgs{
+		Algorithm: pulumi.String("RSA"),
+		RsaBits:   pulumi.Int(2048),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create private key for CA: %w", err)
+	}
+
+	caRoot, err := program.PulumiRun(ctx, tls.NewSelfSignedCert, fmt.Sprintf("ca-cert:%s", name), &tls.SelfSignedCertArgs{
+		PrivateKeyPem: key.PrivateKeyPem,
+
+		ValidityPeriodHours: pulumi.Int(87600),
+		IsCaCertificate:     pulumi.Bool(true),
+		AllowedUses:         pulumi.ToStringArray([]string{"cert_signing"}),
+		Subject: tls.SelfSignedCertSubjectArgs{
+			CommonName: pulumi.String(name),
+		},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA certificate: %w", err)
+	}
+
+	return &PKI{
+		ctx: ctx,
+		Certificate: &Certificate{
+			PrivateKeyPem:  key.PrivateKeyPem,
+			CertificatePem: caRoot.CertPem,
+		},
+	}, nil
+}
+
+func (n *PKI) NewCertificate(name string, options ...func(*Certificate)) (*Certificate, error) {
+	certificate := &Certificate{}
+
+	for _, o := range options {
+		o(certificate)
+	}
+
+	certKey, err := program.PulumiRun(n.ctx, tls.NewPrivateKey, name, &tls.PrivateKeyArgs{
+		Algorithm: pulumi.String("RSA"),
+		RsaBits:   pulumi.Int(2048),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := program.PulumiRun(n.ctx, tls.NewCertRequest, name, &tls.CertRequestArgs{
+		PrivateKeyPem: certKey.PrivateKeyPem,
+		IpAddresses:   certificate.ipAddreses,
+
+		Subject: tls.CertRequestSubjectArgs{
+			CommonName: pulumi.String(name),
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	cert, err := program.PulumiRun(n.ctx, tls.NewLocallySignedCert, name, &tls.LocallySignedCertArgs{
+		CertRequestPem: req.CertRequestPem,
+
+		CaPrivateKeyPem: n.Certificate.PrivateKeyPem,
+		CaCertPem:       n.Certificate.CertificatePem,
+
+		ValidityPeriodHours: pulumi.Int(8784),
+		EarlyRenewalHours:   pulumi.Int(360),
+		AllowedUses:         pulumi.ToStringArray(certificate.allowedUsages),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Certificate{
+		PrivateKeyPem:  certKey.PrivateKeyPem,
+		CertificatePem: cert.CertPem,
+	}, nil
+}
+
+func WithIPAddesses(ips pulumi.StringArray) func(*Certificate) {
+	return func(c *Certificate) {
+		c.ipAddreses = ips
+	}
+}
+
+func WithAllowedUsages(usages []string) func(*Certificate) {
+	return func(c *Certificate) {
+		c.allowedUsages = usages
+	}
+}

--- a/pkg/phkh/compile.go
+++ b/pkg/phkh/compile.go
@@ -233,6 +233,7 @@ func configureFwForK3s(fw *firewall.Config, config *config.Config, node *config.
 }
 
 func configureOSForK3S(os os.OperatingSystem, node *config.NodeConfig, auditLog *audit.AuditLog) {
+	os.SetupJournalD(node.OS.JournalD)
 	os.AddK3SModule(node.Role, node.K3s, auditLog)
 	os.SetupSSHD(&sshd.Params{
 		AcceptEnv: "INSTALL_K3S_* PULUMI_*",


### PR DESCRIPTION
1. Add journald-remote and upload services. You can secure it with TLS.
- [ ] add description
- [ ] improve enable/disable toggles
2. Right now audit logs are pushed to stdout:
- [ ] add docs
- [ ] allow change output to file
3. Additional dependencies added: tls provider
- [ ] add version
4. Add a simple pod with journalctl for searching:
- [ ] implement it


